### PR TITLE
fix types and protect against undefined selectedItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix SSR and consider that selectedItem might be undefined.
 
 ## [1.4.0] - 2020-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Fix SSR and consider that selectedItem might be undefined.
+- Add fallback values to `measurementUnit` and `unitMultiplier`.
 
 ## [1.4.0] - 2020-04-28
 

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -49,7 +49,7 @@ const BaseProductQuantity: StorefrontFunctionComponent<Props> = ({
   }
 
   const unitMultiplier = selectedItem?.unitMultiplier ?? 1
-  const measurementUnit = selectedItem?.measurementUnit ?? 'un'
+  const measurementUnit = selectedItem?.measurementUnit ?? DEFAULT_UNIT
   const showAvailable = availableQuantity <= warningQuantityThreshold
 
   return (

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -48,8 +48,8 @@ const BaseProductQuantity: StorefrontFunctionComponent<Props> = ({
     return null
   }
 
-  const { unitMultiplier, measurementUnit } = selectedItem
-
+  const unitMultiplier = selectedItem?.unitMultiplier ?? 1
+  const measurementUnit = selectedItem?.measurementUnit ?? 'un'
   const showAvailable = availableQuantity <= warningQuantityThreshold
 
   return (

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback } from 'react'
 import { NumericStepper } from 'vtex.styleguide'
 import { FormattedMessage } from 'react-intl'
-import { pathOr } from 'ramda'
 import { useCssHandles } from 'vtex.css-handles'
 
 export type NumericSize = 'small' | 'regular' | 'large'
 
 export interface Props {
   dispatch: any
-  selectedItem: any
+  selectedItem?: SelectedItem
   showLabel?: boolean
   selectedQuantity: number
   size?: NumericSize
@@ -40,16 +39,16 @@ const BaseProductQuantity: StorefrontFunctionComponent<Props> = ({
     [dispatch]
   )
 
-  const availableQuantity = pathOr(
-    0,
-    ['sellers', 0, 'commertialOffer', 'AvailableQuantity'],
-    selectedItem
-  )
+  const availableQuantity = selectedItem?.sellers?.[0]?.commertialOffer?.AvailableQuantity ?? 0
+  if (availableQuantity < 1 || !selectedItem) {
+    return null
+  }
+
   const { unitMultiplier, measurementUnit } = selectedItem
 
   const showAvailable = availableQuantity <= warningQuantityThreshold
 
-  if (availableQuantity < 1) return null
+
 
   return (
     <div
@@ -66,7 +65,7 @@ const BaseProductQuantity: StorefrontFunctionComponent<Props> = ({
           minValue={1}
           unitMultiplier={unitMultiplier}
           suffix={
-            measurementUnit !== DEFAULT_UNIT ? measurementUnit : undefined
+            measurementUnit && measurementUnit !== DEFAULT_UNIT ? measurementUnit : undefined
           }
           onChange={onChange}
           value={selectedQuantity}

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -2,12 +2,14 @@ import React, { useCallback } from 'react'
 import { NumericStepper } from 'vtex.styleguide'
 import { FormattedMessage } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
+import { DispatchFunction } from 'vtex.product-context/ProductDispatchContext'
+import { ProductContext } from 'vtex.product-context'
 
 export type NumericSize = 'small' | 'regular' | 'large'
 
 export interface Props {
-  dispatch: any
-  selectedItem?: SelectedItem
+  dispatch: DispatchFunction
+  selectedItem?: ProductContext['selectedItem']
   showLabel?: boolean
   selectedQuantity: number
   size?: NumericSize
@@ -39,7 +41,9 @@ const BaseProductQuantity: StorefrontFunctionComponent<Props> = ({
     [dispatch]
   )
 
-  const availableQuantity = selectedItem?.sellers?.[0]?.commertialOffer?.AvailableQuantity ?? 0
+  const availableQuantity =
+    selectedItem?.sellers?.[0]?.commertialOffer?.AvailableQuantity ?? 0
+
   if (availableQuantity < 1 || !selectedItem) {
     return null
   }
@@ -47,8 +51,6 @@ const BaseProductQuantity: StorefrontFunctionComponent<Props> = ({
   const { unitMultiplier, measurementUnit } = selectedItem
 
   const showAvailable = availableQuantity <= warningQuantityThreshold
-
-
 
   return (
     <div
@@ -65,7 +67,9 @@ const BaseProductQuantity: StorefrontFunctionComponent<Props> = ({
           minValue={1}
           unitMultiplier={unitMultiplier}
           suffix={
-            measurementUnit && measurementUnit !== DEFAULT_UNIT ? measurementUnit : undefined
+            measurementUnit && measurementUnit !== DEFAULT_UNIT
+              ? measurementUnit
+              : undefined
           }
           onChange={onChange}
           value={selectedQuantity}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,0 +1,9 @@
+interface SelectedItem {
+  unitMultiplier: number
+  measurementUnit: string
+  sellers: Array<{
+    commertialOffer: {
+      AvailableQuantity: number
+    }
+  }>
+}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,9 +1,0 @@
-interface SelectedItem {
-  unitMultiplier: number
-  measurementUnit: string
-  sellers: Array<{
-    commertialOffer: {
-      AvailableQuantity: number
-    }
-  }>
-}

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -1,14 +1,26 @@
 declare module 'vtex.product-context/useProduct' {
   const useProduct: () => ProductContext
   export default useProduct
+}
 
-  interface ProductContext {
+declare module 'vtex.product-context' {
+  export interface ProductContext {
     selectedQuantity: number
     selectedItem?: SelectedItem
+  }
+
+  interface SelectedItem {
+    unitMultiplier: number
+    measurementUnit: string
+    sellers: Array<{
+      commertialOffer: {
+        AvailableQuantity: number
+      }
+    }>
   }
 }
 
 declare module 'vtex.product-context/ProductDispatchContext' {
-  type DispatchFunction = (payload: { type: string; args?: any }) => void
+  type DispatchFunction = (payload: { type: string; args?: object }) => void
   export const useProductDispatch: () => DispatchFunction
 }

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -4,15 +4,7 @@ declare module 'vtex.product-context/useProduct' {
 
   interface ProductContext {
     selectedQuantity: number
-    selectedItem: {
-      sellers: Array<{
-        unitMultiplier: number
-        measurementUnit: string
-        commertialOffer: {
-          AvailableQuantity: number
-        }
-      }>
-    }
+    selectedItem?: SelectedItem
   }
 }
 

--- a/react/typings/vtex.product-summary-context.d.ts
+++ b/react/typings/vtex.product-summary-context.d.ts
@@ -2,13 +2,7 @@ declare module 'vtex.product-summary-context/ProductSummaryContext' {
   export const useProductSummary: () => ProductSummaryContext
   interface ProductSummaryContext {
     selectedQuantity: number
-    selectedItem: {
-      sellers: Array<{
-        commertialOffer: {
-          AvailableQuantity: number
-        }
-      }>
-    }
+    selectedItem?: SelectedItem
   }
 
   type DispatchFunction = (payload: { type: string; args?: any }) => void

--- a/react/typings/vtex.product-summary-context.d.ts
+++ b/react/typings/vtex.product-summary-context.d.ts
@@ -5,6 +5,16 @@ declare module 'vtex.product-summary-context/ProductSummaryContext' {
     selectedItem?: SelectedItem
   }
 
-  type DispatchFunction = (payload: { type: string; args?: any }) => void
+  interface SelectedItem {
+    unitMultiplier: number
+    measurementUnit: string
+    sellers: Array<{
+      commertialOffer: {
+        AvailableQuantity: number
+      }
+    }>
+  }
+
+  type DispatchFunction = (payload: { type: string; args?: object }) => void
   export const useProductSummaryDispatch: () => DispatchFunction
 }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -11,7 +11,7 @@ declare module 'vtex.styleguide' {
     minValue: number
     maxValue?: number
     unitMultiplier: number
-    suffix: string
+    suffix?: string
     onChange: (e: any) => void
   }
 }


### PR DESCRIPTION
**What problem is this solving?**

`const { unitMultiplier, measurementUnit } = selectedItem`

This line is breaking stuff in ssr because `selectedItem` may be undefined

**How should this be manually tested?**

**Screenshots or example usage:**