### PR TITLE
Feature: add dropdown support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Add support to dropdown quantity selection behavior
+- `selectorType` prop to `product-quantity` and `product-summary-quantity`. Enables users to toggle between a dropdown and a numeric stepper.
 
 ## [1.4.1] - 2020-05-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support to dropdown quantity selection behavior
 
 ## [1.4.1] - 2020-05-01
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ Check an example of a Product Details Page built using Flex Layout with the `pro
 | `warningQuantityThreshold` | `Number` | Displays the quantity of remaining items in stock if the available quantity is less than or equal to the value given to this property. Default: 0 (does not appear). | `0` |
 | `size` | `NumericSize`| Preset values `font-size` and `padding` to the component | `'small'` |
 | `showLabel` | `boolean` | If it should show a label | `true` |
+| `selectorType` | `SelectorType` | Determines the initial behavior of the selector | `'input'` |
 
 ### NumericSize
 
@@ -64,18 +65,28 @@ You can check how big these values are and what classes it aplies by going to th
 | `'regular'` | Medium size |
 | `'large'` | Large size |
 
+### SelectorType
+
+You can use SelectorType to indicate how the quantity selector should behave initially.
+
+| Value | Description |
+| --- | --- |
+| `'input'` | Shows an input field where the quantity can be entered directly. Also presents side buttons that can be used to increase or decrease the value |
+| `'dropdown'` | Shows a preset list of quantity options. If the last option is selected, the behavior is updated to `'input'` |
 
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization). 
 
-| CSS Handles                  |
-| ---------------------------- | 
-| `quantitySelectorContainer`  |
-| `availableQuantityContainer` | 
-| `quantitySelectorTitle`      |
-| `quantitySelectorStepper`    |
-| `summaryContainer`           | 
+| CSS Handles                                |
+| ------------------------------------------ | 
+| `quantitySelectorContainer`                |
+| `availableQuantityContainer`               | 
+| `quantitySelectorTitle`                    |
+| `quantitySelectorStepper`                  |
+| `quantitySelectorDropdownMobileContainer`  |
+| `quantitySelectorDropdownContainer`        |
+| `summaryContainer`                         | 
 
 ## Contributors ✨
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ You are now able to use all blocks that are exported by the Product Quantity app
 | `warningQuantityThreshold` | `number` | Displays the quantity of remaining items in stock if the available quantity is less than or equal to the value given to this property. | `0` (the quantity is not displayed) |
 | `size` | `enum`| Preset size values for `font-size` and `padding`. You can check these value measures by accessing the [VTEX Styleguide](https://styleguide.vtex.com/#/Components/Forms/NumericStepper). Possible values are: `small`, `regular`, and `large`. | `small` |
 | `showLabel` | `boolean` | Whether a label should be displayed (`true`) or not (`false`). | `true` |
-| `selectorType` | `enum` | Defines how the quantity selector should initially behave. Possible values are: `input` (displays an input field where the quantity can be directly defined, in addition to side buttons to increase or decrease the value) and `dropdown` (shows a list of predefined-quantity options. In case the last quantity option is selected by users, the component starts to behave according to the `input` prop). | `input` |
+| `selectorType` | `enum` | Defines how the quantity selector should initially behave. Possible values are: `stepper` (displays an input field where the quantity can be directly defined, in addition to side buttons to increase or decrease the value) and `dropdown` (shows a list of predefined-quantity options. In case the last quantity option is selected by users, the component starts to behave according to the `stepper` prop). | `stepper` |
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ You are now able to use all blocks that are exported by the Product Quantity app
 | `warningQuantityThreshold` | `number` | Displays the quantity of remaining items in stock if the available quantity is less than or equal to the value given to this property. | `0` (the quantity is not displayed) |
 | `size` | `enum`| Preset size values for `font-size` and `padding`. You can check these value measures by accessing the [VTEX Styleguide](https://styleguide.vtex.com/#/Components/Forms/NumericStepper). Possible values are: `small`, `regular`, and `large`. | `small` |
 | `showLabel` | `boolean` | Whether a label should be displayed (`true`) or not (`false`). | `true` |
-| `selectorType` | `enum` | Defines how the quantity selector should initially behave. Possible values are: `stepper` (displays an input field where the quantity can be directly defined, in addition to side buttons to increase or decrease the value) and `dropdown` (shows a list of predefined-quantity options. In case the last quantity option is selected by users, the component starts to behave according to the `stepper` prop). | `stepper` |
+| `selectorType` | `enum` | Defines how the quantity selector should initially behave. Possible values are: `stepper` (displays an input field where the quantity can be directly defined, in addition to side buttons to increase or decrease the value) and `dropdown` (shows a list of predefined-quantity options. In case the last quantity option is selected by users, the component is replaced with an input). | `stepper` |
 
 ## Customization
 
@@ -75,6 +75,8 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `quantitySelectorContainer`                |
 | `quantitySelectorDropdownContainer`        |
 | `quantitySelectorDropdownMobileContainer`  |
+| `quantitySelectorInputContainer`           |
+| `quantitySelectorInputMobileContainer`     |
 | `quantitySelectorStepper`                  |
 | `quantitySelectorTitle`                    |
 | `summaryContainer`                         |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,18 @@
-📢 Don't fork this project. Use, [contribute](https://github.com/vtex-apps/awesome-io#contributing), or open issues through [Store Discussion](https://github.com/vtex-apps/store-discussion).
+📢 Don't fork this project. Use, [contribute](https://github.com/vtex-apps/product-quantity), or open issues through [Store Discussion](https://github.com/vtex-apps/store-discussion).
+
+# Product Quantity
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-# Product Quantity
-
-The Product Quantity allows users to a **add a chosen amount** of the displayed product in their cart.
+The Product Quantity allows users to a add a chosen amount of the displayed product in their cart.
 
 ![product-quantity](https://user-images.githubusercontent.com/52087100/70237475-0f4bd900-1746-11ea-9af2-38f794f4a3dd.png)
 
 ## Configuration 
 
-1. Import the Product Quantity to your dependencies on `manifest.json` file.
+1. Add the Product Quantity app to your dependencies in the theme's `manifest.json` file:
 
 ```json
   "dependencies": {
@@ -19,11 +20,16 @@ The Product Quantity allows users to a **add a chosen amount** of the displayed 
   }
 ```
 
-2. Add the Product Quantity block to your theme. If you want to display it on a Product Page, you should declare the `product-quantity` in the `store.product` block. In order to display it in a Product Summary block, i.e. in blocks that use Product Summary, declare the `product-summary-quantity` in the `product-summary.shelf` block.
+You are now able to use all blocks that are exported by the Product Quantity app. Check out the full list below:
 
-Check an example of a Product Details Page built using Flex Layout with the `product-quantity` below:
+| Block name | Description | 
+| --------- | ------------ |
+| `product-quantity` | Displays a quantity selector on the product details page. This block must be declared in the theme's `store.product` page template. | 
+| `product-summary-quantity` | Displays a quantity selector on [Product Summary](https://vtex.io/docs/components/all/vtex.product-summary/)'s blocks. This block must be declared as a children of the `product-summary.shelf` block. | 
 
-```json
+2. According to your desired scenario, add the `product-quantity`/`product-summary-quantity` blocks to your theme. For example:
+
+```diff
   "flex-layout.col#product-price": {
     "props": {
       "preventVerticalStretch": true,
@@ -33,7 +39,7 @@ Check an example of a Product Details Page built using Flex Layout with the `pro
       "product-name",
       "product-price#product-details",
       "product-separator",
-+      "product-quantity",
++     "product-quantity",
       "sku-selector",
       "flex-layout.row#buy-button",
       "availability-subscriber",
@@ -48,31 +54,16 @@ Check an example of a Product Details Page built using Flex Layout with the `pro
   },
 ```
 
+*In the example above a Product Details Page is built using Flex Layout and the `product-quantity` block.*
+
+### `product-quantity` and `product-summary-quantity` props
+
 | Prop name | Type | Description | Default Value |
 | --- | --- | --- | --- |
-| `warningQuantityThreshold` | `Number` | Displays the quantity of remaining items in stock if the available quantity is less than or equal to the value given to this property. Default: 0 (does not appear). | `0` |
-| `size` | `NumericSize`| Preset values `font-size` and `padding` to the component | `'small'` |
-| `showLabel` | `boolean` | If it should show a label | `true` |
-| `selectorType` | `SelectorType` | Determines the initial behavior of the selector | `'input'` |
-
-### NumericSize
-
-You can check how big these values are and what classes it aplies by going to the [styleguide docs](https://styleguide.vtex.com/#/Components/Forms/NumericStepper).
-
-| Value | Description |
-| --- | --- |
-| `'small'` | Small size |
-| `'regular'` | Medium size |
-| `'large'` | Large size |
-
-### SelectorType
-
-You can use SelectorType to indicate how the quantity selector should behave initially.
-
-| Value | Description |
-| --- | --- |
-| `'input'` | Shows an input field where the quantity can be entered directly. Also presents side buttons that can be used to increase or decrease the value |
-| `'dropdown'` | Shows a preset list of quantity options. If the last option is selected, the behavior is updated to `'input'` |
+| `warningQuantityThreshold` | `number` | Displays the quantity of remaining items in stock if the available quantity is less than or equal to the value given to this property. | `0` (the quantity is not displayed) |
+| `size` | `enum`| Preset size values for `font-size` and `padding`. You can check these value measures by accessing the [VTEX Styleguide](https://styleguide.vtex.com/#/Components/Forms/NumericStepper). Possible values are: `small`, `regular`, and `large`. | `small` |
+| `showLabel` | `boolean` | Whether a label should be displayed (`true`) or not (`false`). | `true` |
+| `selectorType` | `enum` | Defines how the quantity selector should initially behave. Possible values are: `input` (displays an input field where the quantity can be directly defined, in addition to side buttons to increase or decrease the value) and `dropdown` (shows a list of predefined-quantity options. In case the last quantity option is selected by users, the component starts to behave according to the `input` prop). | `input` |
 
 ## Customization
 
@@ -80,17 +71,19 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 
 | CSS Handles                                |
 | ------------------------------------------ | 
+| `availableQuantityContainer`               |
 | `quantitySelectorContainer`                |
-| `availableQuantityContainer`               | 
-| `quantitySelectorTitle`                    |
-| `quantitySelectorStepper`                  |
-| `quantitySelectorDropdownMobileContainer`  |
 | `quantitySelectorDropdownContainer`        |
-| `summaryContainer`                         | 
+| `quantitySelectorDropdownMobileContainer`  |
+| `quantitySelectorStepper`                  |
+| `quantitySelectorTitle`                    |
+| `summaryContainer`                         |
+
+<!-- DOCS-IGNORE:start -->
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people:
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
@@ -106,3 +99,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
+
+<!-- DOCS-IGNORE:end -->
+

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,8 @@
     "vtex.styleguide": "9.x",
     "vtex.product-context": "0.x",
     "vtex.product-summary-context": "0.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "0.x",
+    "vtex.device-detector": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/ProductQuantity.tsx
+++ b/react/ProductQuantity.tsx
@@ -2,12 +2,15 @@ import React from 'react'
 import useProduct from 'vtex.product-context/useProduct'
 import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
 
-import BaseProductQuantity, { Props } from './components/BaseProductQuantity'
+import BaseProductQuantity, {
+  BaseProps,
+} from './components/BaseProductQuantity'
 
-const ProductQuantity: StorefrontFunctionComponent<Props> = props => {
-  const { warningQuantityThreshold, showLabel, size } = props
+const ProductQuantity: StorefrontFunctionComponent<BaseProps> = props => {
+  const { warningQuantityThreshold, showLabel, size, selectorType } = props
   const { selectedItem, selectedQuantity } = useProduct()
   const dispatch = useProductDispatch()
+
   return (
     <BaseProductQuantity
       size={size}
@@ -15,6 +18,7 @@ const ProductQuantity: StorefrontFunctionComponent<Props> = props => {
       showLabel={showLabel}
       selectedItem={selectedItem}
       selectedQuantity={selectedQuantity}
+      selectorType={selectorType}
       warningQuantityThreshold={warningQuantityThreshold}
     />
   )

--- a/react/ProductSummaryQuantity.tsx
+++ b/react/ProductSummaryQuantity.tsx
@@ -3,12 +3,14 @@ import { useCssHandles } from 'vtex.css-handles'
 import useProduct from 'vtex.product-context/useProduct'
 import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
 
-import BaseProductQuantity, { Props } from './components/BaseProductQuantity'
+import BaseProductQuantity, {
+  BaseProps,
+} from './components/BaseProductQuantity'
 
 const CSS_HANDLES = ['summaryContainer'] as const
 
-const ProductSummaryQuantity: StorefrontFunctionComponent<Props> = props => {
-  const { warningQuantityThreshold, showLabel, size } = props
+const ProductSummaryQuantity: StorefrontFunctionComponent<BaseProps> = props => {
+  const { warningQuantityThreshold, showLabel, size, selectorType } = props
   const handles = useCssHandles(CSS_HANDLES)
   const { selectedItem, selectedQuantity } = useProduct()
   const dispatch = useProductDispatch()
@@ -30,6 +32,7 @@ const ProductSummaryQuantity: StorefrontFunctionComponent<Props> = props => {
         showLabel={showLabel}
         selectedItem={selectedItem}
         selectedQuantity={selectedQuantity}
+        selectorType={selectorType}
         warningQuantityThreshold={warningQuantityThreshold}
       />
     </div>

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import { DispatchFunction } from 'vtex.product-context/ProductDispatchContext'
@@ -28,7 +28,6 @@ const CSS_HANDLES = [
 
 export type OnChangeCallback = {
   value: number
-  selector?: BaseProps['selectorType']
 }
 
 const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
@@ -41,14 +40,9 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
   selectorType = 'stepper',
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  const [curSelector, setSelector] = useState(selectorType)
   const onChange = useCallback(
     (e: OnChangeCallback) => {
       dispatch({ type: 'SET_QUANTITY', args: { quantity: e.value } })
-
-      if (e.selector) {
-        setSelector(e.selector)
-      }
     },
     [dispatch]
   )
@@ -71,7 +65,7 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
           <FormattedMessage id="store/product-quantity.quantity" />
         </div>
       )}
-      {curSelector === 'stepper' ? (
+      {selectorType === 'stepper' ? (
         <StepperProductQuantity
           size={size}
           unitMultiplier={selectedItem.unitMultiplier}
@@ -81,7 +75,7 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
           onChange={onChange}
         />
       ) : null}
-      {curSelector === 'dropdown' ? (
+      {selectorType === 'dropdown' ? (
         <DropdownProductQuantity
           itemId={selectedItem.itemId}
           selectedQuantity={selectedQuantity}

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -65,7 +65,7 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
           <FormattedMessage id="store/product-quantity.quantity" />
         </div>
       )}
-      {selectorType === 'stepper' ? (
+      {selectorType === 'stepper' && (
         <StepperProductQuantity
           size={size}
           unitMultiplier={selectedItem.unitMultiplier}
@@ -74,8 +74,8 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
           availableQuantity={availableQuantity}
           onChange={onChange}
         />
-      ) : null}
-      {selectorType === 'dropdown' ? (
+      )}
+      {selectorType === 'dropdown' && (
         <DropdownProductQuantity
           itemId={selectedItem.itemId}
           selectedQuantity={selectedQuantity}
@@ -83,7 +83,7 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
           onChange={onChange}
           size={size}
         />
-      ) : null}
+      )}
       {showAvailable && (
         <div
           className={`${handles.availableQuantityContainer} mv4 c-muted-2 t-small`}>

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -5,10 +5,10 @@ import { DispatchFunction } from 'vtex.product-context/ProductDispatchContext'
 import { ProductContext } from 'vtex.product-context'
 
 import DropdownProductQuantity from './DropdownProductQuantity'
-import InputProductQuantity from './InputProductQuantity'
+import StepperProductQuantity from './StepperProductQuantity'
 
 export type NumericSize = 'small' | 'regular' | 'large'
-export type SelectorType = 'input' | 'dropdown'
+export type SelectorType = 'stepper' | 'dropdown'
 
 export interface BaseProps {
   dispatch: DispatchFunction
@@ -38,7 +38,7 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
   showLabel = true,
   selectedQuantity,
   warningQuantityThreshold = 0,
-  selectorType = 'input',
+  selectorType = 'stepper',
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const [curSelector, setSelector] = useState(selectorType)
@@ -71,8 +71,8 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
           <FormattedMessage id="store/product-quantity.quantity" />
         </div>
       )}
-      {curSelector === 'input' ? (
-        <InputProductQuantity
+      {curSelector === 'stepper' ? (
+        <StepperProductQuantity
           size={size}
           unitMultiplier={selectedItem.unitMultiplier}
           measurementUnit={selectedItem.measurementUnit}

--- a/react/components/DropdownProductQuantity.tsx
+++ b/react/components/DropdownProductQuantity.tsx
@@ -1,0 +1,105 @@
+import React, { FunctionComponent, Fragment } from 'react'
+import { Dropdown } from 'vtex.styleguide'
+import { useCssHandles } from 'vtex.css-handles'
+import { SelectedItem } from 'vtex.product-context'
+
+import { OnChangeCallback, BaseProps } from './BaseProductQuantity'
+
+const MAX_DROPDOWN_VALUE = 10
+
+interface DropdownProps {
+  itemId: SelectedItem['itemId']
+  selectedQuantity: BaseProps['selectedQuantity']
+  availableQuantity: number
+  onChange: (e: OnChangeCallback) => void
+  size: BaseProps['size']
+}
+
+const normalizeValue = (value: number, maxValue: number) =>
+  value > maxValue ? maxValue : value
+
+const validateValue = (value: string, maxValue: number) => {
+  const parsedValue = parseInt(value, 10)
+
+  if (Number.isNaN(parsedValue)) {
+    return 1
+  }
+
+  return normalizeValue(parseInt(value, 10), maxValue)
+}
+
+const getDropdownOptions = (maxValue: number) => {
+  const limit = Math.min(MAX_DROPDOWN_VALUE - 1, maxValue)
+  const options = []
+
+  for (let idx = 1; idx <= limit; ++idx) {
+    options.push({ value: idx, label: `${idx}` })
+  }
+
+  if (maxValue >= MAX_DROPDOWN_VALUE) {
+    options.push({
+      value: MAX_DROPDOWN_VALUE,
+      label: `${MAX_DROPDOWN_VALUE}+`,
+    })
+  }
+
+  return options
+}
+
+const CSS_HANDLES = [
+  'quantityDropdownMobileContainer',
+  'quantityDropdownContainer',
+] as const
+
+const DropdownProductQuantity: FunctionComponent<DropdownProps> = ({
+  itemId,
+  selectedQuantity,
+  size = 'small',
+  onChange,
+  availableQuantity,
+}) => {
+  const handles = useCssHandles(CSS_HANDLES)
+  const dropdownOptions = getDropdownOptions(availableQuantity)
+
+  const handleDropdownChange = (value: string) => {
+    const validatedValue = validateValue(value, availableQuantity)
+
+    let selector: BaseProps['selectorType']
+
+    if (validatedValue >= Math.min(availableQuantity, MAX_DROPDOWN_VALUE)) {
+      selector = 'input'
+    }
+
+    onChange({ value: validatedValue, selector })
+  }
+  return (
+    <Fragment>
+      <div
+        className={`${handles.quantityDropdownMobileContainer} dn-m`}
+        style={{ zIndex: 8888 }}>
+        <Dropdown
+          id={`quantity-dropdown-mobile-${itemId}`}
+          testId={`quantity-dropdown-mobile-${itemId}`}
+          options={dropdownOptions}
+          size={size}
+          value={selectedQuantity}
+          onChange={(event: any) => handleDropdownChange(event.target.value)}
+          placeholder=" "
+        />
+      </div>
+      <div className={`${handles.quantityDropdownContainer} dn db-m`}>
+        <Dropdown
+          id={`quantity-dropdown-${itemId}`}
+          testId={`quantity-dropdown-${itemId}`}
+          options={dropdownOptions}
+          size={size}
+          value={selectedQuantity}
+          onChange={(event: any) => handleDropdownChange(event.target.value)}
+          placeholder=" "
+        />
+      </div>
+    </Fragment>
+  )
+}
+
+export default DropdownProductQuantity

--- a/react/components/DropdownProductQuantity.tsx
+++ b/react/components/DropdownProductQuantity.tsx
@@ -67,7 +67,7 @@ const DropdownProductQuantity: FunctionComponent<DropdownProps> = ({
     let selector: BaseProps['selectorType']
 
     if (validatedValue >= Math.min(availableQuantity, MAX_DROPDOWN_VALUE)) {
-      selector = 'input'
+      selector = 'stepper'
     }
 
     onChange({ value: validatedValue, selector })

--- a/react/components/DropdownProductQuantity.tsx
+++ b/react/components/DropdownProductQuantity.tsx
@@ -47,8 +47,8 @@ const getDropdownOptions = (maxValue: number) => {
 }
 
 const CSS_HANDLES = [
-  'quantityDropdownMobileContainer',
-  'quantityDropdownContainer',
+  'quantitySelectorDropdownMobileContainer',
+  'quantitySelectorDropdownContainer',
 ] as const
 
 const DropdownProductQuantity: FunctionComponent<DropdownProps> = ({
@@ -75,8 +75,7 @@ const DropdownProductQuantity: FunctionComponent<DropdownProps> = ({
   return (
     <Fragment>
       <div
-        className={`${handles.quantityDropdownMobileContainer} dn-m`}
-        style={{ zIndex: 8888 }}>
+        className={`${handles.quantitySelectorDropdownMobileContainer} dn-m`}>
         <Dropdown
           id={`quantity-dropdown-mobile-${itemId}`}
           testId={`quantity-dropdown-mobile-${itemId}`}
@@ -87,7 +86,7 @@ const DropdownProductQuantity: FunctionComponent<DropdownProps> = ({
           placeholder=" "
         />
       </div>
-      <div className={`${handles.quantityDropdownContainer} dn db-m`}>
+      <div className={`${handles.quantitySelectorDropdownContainer} dn db-m`}>
         <Dropdown
           id={`quantity-dropdown-${itemId}`}
           testId={`quantity-dropdown-${itemId}`}

--- a/react/components/InputProductQuantity.tsx
+++ b/react/components/InputProductQuantity.tsx
@@ -1,0 +1,45 @@
+import React, { FunctionComponent } from 'react'
+import { NumericStepper } from 'vtex.styleguide'
+import { useCssHandles } from 'vtex.css-handles'
+import { SelectedItem } from 'vtex.product-context'
+
+import { OnChangeCallback, BaseProps } from './BaseProductQuantity'
+
+const DEFAULT_UNIT = 'un'
+
+interface InputProps {
+  unitMultiplier: SelectedItem['unitMultiplier']
+  measurementUnit: SelectedItem['measurementUnit']
+  selectedQuantity: BaseProps['selectedQuantity']
+  availableQuantity: number
+  onChange: (e: OnChangeCallback) => void
+  size: BaseProps['size']
+}
+const CSS_HANDLES = ['quantitySelectorStepper'] as const
+
+const InputProductQuantity: FunctionComponent<InputProps> = ({
+  unitMultiplier = 1,
+  measurementUnit = DEFAULT_UNIT,
+  size = 'small',
+  selectedQuantity,
+  availableQuantity,
+  onChange,
+}) => {
+  const handles = useCssHandles(CSS_HANDLES)
+
+  return (
+    <div className={handles.quantitySelectorStepper}>
+      <NumericStepper
+        size={size}
+        minValue={1}
+        unitMultiplier={unitMultiplier}
+        suffix={measurementUnit !== DEFAULT_UNIT ? measurementUnit : undefined}
+        onChange={onChange}
+        value={selectedQuantity}
+        maxValue={availableQuantity || undefined}
+      />
+    </div>
+  )
+}
+
+export default InputProductQuantity

--- a/react/components/StepperProductQuantity.tsx
+++ b/react/components/StepperProductQuantity.tsx
@@ -7,7 +7,7 @@ import { OnChangeCallback, BaseProps } from './BaseProductQuantity'
 
 const DEFAULT_UNIT = 'un'
 
-interface InputProps {
+interface StepperProps {
   unitMultiplier: SelectedItem['unitMultiplier']
   measurementUnit: SelectedItem['measurementUnit']
   selectedQuantity: BaseProps['selectedQuantity']
@@ -17,7 +17,7 @@ interface InputProps {
 }
 const CSS_HANDLES = ['quantitySelectorStepper'] as const
 
-const InputProductQuantity: FunctionComponent<InputProps> = ({
+const StepperProductQuantity: FunctionComponent<StepperProps> = ({
   unitMultiplier = 1,
   measurementUnit = DEFAULT_UNIT,
   size = 'small',
@@ -42,4 +42,4 @@ const InputProductQuantity: FunctionComponent<InputProps> = ({
   )
 }
 
-export default InputProductQuantity
+export default StepperProductQuantity

--- a/react/components/StepperProductQuantity.tsx
+++ b/react/components/StepperProductQuantity.tsx
@@ -15,6 +15,7 @@ interface StepperProps {
   onChange: (e: OnChangeCallback) => void
   size: BaseProps['size']
 }
+
 const CSS_HANDLES = ['quantitySelectorStepper'] as const
 
 const StepperProductQuantity: FunctionComponent<StepperProps> = ({

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,14 @@
     "@types/react-intl": "^2.3.17",
     "@vtex/test-tools": "^0.2.0",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3"
+    "typescript": "3.8.3",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
+    "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.5/public/@types/vtex.device-detector",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context",
+    "vtex.product-summary-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.5.0/public/@types/vtex.product-summary-context",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.122.2/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide"
   },
   "version": "1.4.1"
 }

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -10,6 +10,7 @@ declare module 'vtex.product-context' {
   }
 
   interface SelectedItem {
+    itemId: string
     unitMultiplier: number
     measurementUnit: string
     sellers: Array<{

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -2,6 +2,7 @@ declare module 'vtex.styleguide' {
   import { ComponentType } from 'react'
 
   export const NumericStepper: ComponentType<NumericStepperProps>
+  export const Dropdown: ComponentType<DropdownProps>
 
   type NumericSize = 'small' | 'regular' | 'large'
 
@@ -13,5 +14,18 @@ declare module 'vtex.styleguide' {
     unitMultiplier: number
     suffix?: string
     onChange: (e: any) => void
+  }
+
+  interface DropdownProps {
+    id: string
+    testId: string
+    onChange: (e: Event) => void
+    placeholder: string
+    options: Array<{
+      value: number
+      label: string
+    }>
+    size: NumericSize
+    value: number
   }
 }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -3,6 +3,7 @@ declare module 'vtex.styleguide' {
 
   export const NumericStepper: ComponentType<NumericStepperProps>
   export const Dropdown: ComponentType<DropdownProps>
+  export const Input: ComponentType<InputProps>
 
   type NumericSize = 'small' | 'regular' | 'large'
 
@@ -19,7 +20,7 @@ declare module 'vtex.styleguide' {
   interface DropdownProps {
     id: string
     testId: string
-    onChange: (e: Event) => void
+    onChange: (e: any) => void
     placeholder: string
     options: Array<{
       value: number
@@ -27,5 +28,15 @@ declare module 'vtex.styleguide' {
     }>
     size: NumericSize
     value: number
+  }
+
+  interface InputProps {
+    id: string
+    size: NumericSize
+    value: string
+    maxLength: number
+    onChange: (e: any) => void
+    onBlur: () => void
+    placeholder: string
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4461,6 +4461,34 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
+  version "0.4.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
+
+"vtex.device-detector@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.5/public/@types/vtex.device-detector":
+  version "0.2.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.5/public/@types/vtex.device-detector#edbc992ee63c728664e67bd165af56cedd17a6c4"
+
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types":
+  version "0.7.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
+
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context":
+  version "0.9.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context#f4387e4b4ec59cf7e63b8f68202426a279693dd1"
+
+"vtex.product-summary-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.5.0/public/@types/vtex.product-summary-context":
+  version "0.5.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.5.0/public/@types/vtex.product-summary-context#51e4062e3d6f39a1b376416a75fd7bf296c1c085"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.122.2/public/@types/vtex.render-runtime":
+  version "8.122.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.122.2/public/@types/vtex.render-runtime#fa235be2fa6995d12f03f92b20dd3eebb4f3c5fb"
+
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide":
+  version "9.133.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide#1afb6bfeceee829a24d18afb672f1f05d64638ac"
+
 w3c-hr-time@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"


### PR DESCRIPTION
#### What problem is this solving?

Today the component quantity selector can't be used as dropdown and it would be nice for our clients to have this option.

#### How to test it?
[This workspace](https://icaro--storecomponents.myvtex.com/) contains the updated component and it defaults to the previous behavior. It shouldn't behave differently compared to how it did before. I've added product-quantity to the shelf too.

[This workspace](https://icaro2--storecomponents.myvtex.com/) contains the updated component and it is configured to behave as a dropdown both on the shelf and product page.


#### Screenshots or example usage:

<img width="531" alt="Screen Shot 2020-09-25 at 4 51 23 PM" src="https://user-images.githubusercontent.com/8127610/94310049-64fca680-ff4f-11ea-8eff-73a0a5f45c64.png">

#### Describe alternatives you've considered, if any.

I've used the solution present on the [product-list](https://github.com/vtex-apps/product-list) as a base for this implementation.

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/Tsgq6W7VnMZ2/giphy-downsized-large.gif)
