### PR TITLE
Fixing stepper's minimum value behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stepper now uses unitMultiplier value as the minimum accepted value
 
 ## [1.6.0] - 2021-01-13
 ### Added

--- a/react/components/StepperProductQuantity.tsx
+++ b/react/components/StepperProductQuantity.tsx
@@ -30,11 +30,13 @@ const StepperProductQuantity: FunctionComponent<StepperProps> = ({
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
+  const minValue = unitMultiplier
+
   return (
     <div className={handles.quantitySelectorStepper}>
       <NumericStepper
         size={size}
-        minValue={1}
+        minValue={minValue}
         unitMultiplier={unitMultiplier}
         suffix={
           showUnit && measurementUnit !== DEFAULT_UNIT


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes the minimum value used for products with `unitMultiplier` different from 1. Previously, this behavior was guaranted by the stepper itself (from the styleguide), but in an erroneous way. Dealing with that there could create issues.

#### How to test it?

[Workspace](https://iespinoza--biscoind.myvtex.com/alphawire-5857-bk005/p)

#### Screenshots or example usage:

<img width="150" alt="Screen Shot 2021-02-17 at 19 34 58" src="https://user-images.githubusercontent.com/8127610/108276873-3b8b2400-7157-11eb-9150-be48503f907b.png">

#### Related to / Depends on

Related to [styleguide#1366](https://github.com/vtex/styleguide/pull/1366)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->
"stepper"
![](https://media.giphy.com/media/BG69duEBWxv5mlwPKu/giphy.gif)
