### PR TITLE
fix: seller 0 is not always the seller default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Seller default instead of seller 0 in `BaseProductQuantity.tsx` and typing
+
 ## [1.7.0] - 2021-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Seller default instead of seller 0 in `BaseProductQuantity.tsx` and typing
+- Now considers default seller instead of first seller in `BaseProductQuantity`
 
 ## [1.7.0] - 2021-07-26
 

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -53,9 +53,8 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
   )
 
   const availableQuantity =
-    selectedItem?.sellers?.filter(
-      ({ sellerDefault }) => sellerDefault === true
-    )[0]?.commertialOffer?.AvailableQuantity ?? 0
+    selectedItem?.sellers?.find(({ sellerDefault }) => sellerDefault === true)
+      ?.commertialOffer?.AvailableQuantity ?? 0
 
   if (availableQuantity < 1 || !selectedItem) {
     return null

--- a/react/components/BaseProductQuantity.tsx
+++ b/react/components/BaseProductQuantity.tsx
@@ -53,7 +53,9 @@ const BaseProductQuantity: StorefrontFunctionComponent<BaseProps> = ({
   )
 
   const availableQuantity =
-    selectedItem?.sellers?.[0]?.commertialOffer?.AvailableQuantity ?? 0
+    selectedItem?.sellers?.filter(
+      ({ sellerDefault }) => sellerDefault === true
+    )[0]?.commertialOffer?.AvailableQuantity ?? 0
 
   if (availableQuantity < 1 || !selectedItem) {
     return null

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -17,6 +17,7 @@ declare module 'vtex.product-context' {
       commertialOffer: {
         AvailableQuantity: number
       }
+      sellerDefault: boolean
     }>
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Not always the seller[0] is the default seller, especially with Intelligent Search, so, looking for seller 0 was causing some strange behaviors like not showing the quantity selector

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[After](https://iespinoza--locatelcolombia.myvtex.com/m311d14icosegl?_q=M311D14ICOSEGL&map=ft)

![image](https://user-images.githubusercontent.com/13649073/134095180-c876be73-45f2-4f1c-9e21-1651e9a825a3.png)


[Before](https://master--locatelcolombia.myvtex.com/m311d14icosegl?_q=M311D14ICOSEGL&map=ft)

![image](https://user-images.githubusercontent.com/13649073/134095204-76ca5719-fa82-4fab-9e9b-b9bc92625bb0.png)

#### Related to / Depends on

Zendesk: #433243

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/pWEA23mJm9485IXhFV/giphy.gif?cid=ecf05e47awlqat41xm5ah8bft99gn9yzrvoxhrsiigbl4e3e&rid=giphy.gif&ct=g)
