### PR TITLE
fix: input changing to text when selecting maximum available quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Product quantity changing to input text when selecting the maximum available quantity 
 ## [1.8.0] - 2022-03-14
 
 ### Added

--- a/react/components/DropdownProductQuantity.tsx
+++ b/react/components/DropdownProductQuantity.tsx
@@ -93,7 +93,7 @@ const DropdownProductQuantity: FunctionComponent<DropdownProps> = ({
 
     if (
       internalBehavior === 'dropdown' &&
-      newValidatedValue >= Math.min(availableQuantity, MAX_DROPDOWN_VALUE)
+      newValidatedValue >= Math.min(availableQuantity + 1, MAX_DROPDOWN_VALUE)
     ) {
       setInternalBehavior('input')
     }


### PR DESCRIPTION
#### What problem is this solving?

We are changing the input type to text when selecting the maximum available quantity when the input type is a dropdown.

We have the max dropdown value, that triggers the input type text if the user wants to add more than the maximum allowed in the dropdown, but, if it exceeds the max quantity of products available, we should not display the input type text  

#### How to test it?

Select the maximum available quantity in product quantity dropdown

[New behavior](https://iespinoza--callearturop.myvtex.com/jogger-unicolor-detalle-en-costado-hombre-freedom--35002725/p?skuId=55830)

[Old behavior](https://oldqtd--callearturop.myvtex.com/jogger-unicolor-detalle-en-costado-hombre-freedom--35002725/p?skuId=55830)


#### Screenshots or example usage:

<img width="486" alt="image" src="https://user-images.githubusercontent.com/13649073/174849810-64a484ec-09e5-4553-8761-b7bb58227d1c.png">


#### Alternatives

Remove the entire available quantity validation, maintaining only the validation for MAX_DROPDOWN_VALUE. When will the user exceed the maximum available quantity in the dropdown? 

```
    if (
      internalBehavior === 'dropdown' &&
      newValidatedValue >= MAX_DROPDOWN_VALUE
    ) {
      setInternalBehavior('input')
    }
```

[Another purpose](https://purposeqtd--callearturop.myvtex.com/jogger-unicolor-detalle-en-costado-hombre-freedom--35002725/p?skuId=55830)

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/4Zgy9QqzWU8C3ugvCa/giphy.gif)
